### PR TITLE
Add UriBuilder to expose more OTP Auth URI parameters

### DIFF
--- a/src/OtpAuth/Base32.php
+++ b/src/OtpAuth/Base32.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Vectorface\OtpAuth;
+
+class Base32
+{
+    const CHARS = [
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', //  7
+        'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', // 15
+        'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', // 23
+        'Y', 'Z', '2', '3', '4', '5', '6', '7', // 31
+        '=' // 32, padding character
+    ];
+
+    /**
+     * Helper method to encode base32
+     *
+     * @param string $data
+     * @param $length
+     * @return string
+     */
+    public static function encode(string $data, $length = null): string
+    {
+        $length ??= strlen($data);
+        $encoded = '';
+        for ($i = 0; $i < $length; ++$i) {
+            $encoded .= self::CHARS[ord($data[$i]) & 31];
+        }
+        return $encoded;
+    }
+
+    /**
+     * Helper method to decode base32
+     *
+     * @param string $data
+     * @return ?string The decoded string, or null on error
+     */
+    public static function decode(string $data): ?string
+    {
+        if (empty($data)) {
+            return '';
+        }
+
+        $base32charsFlipped = array_flip(self::CHARS);
+        $paddingCharCount = substr_count($data, self::CHARS[32]);
+        $allowedValues = [6, 4, 3, 1, 0];
+        if (!in_array($paddingCharCount, $allowedValues)) {
+            return null;
+        }
+
+        for ($i = 0; $i < 4; $i++){
+            if ($paddingCharCount == $allowedValues[$i] &&
+                substr($data, -($allowedValues[$i])) != str_repeat(self::CHARS[32], $allowedValues[$i])) {
+                return null;
+            }
+        }
+
+        $data = str_replace('=','', $data);
+        $data = str_split($data);
+        $binaryString = "";
+        for ($i = 0; $i < count($data); $i = $i+8) {
+            if (!isset($base32charsFlipped[$data[$i]])) {
+                return null;
+            }
+
+            $x = "";
+            for ($j = 0; $j < 8; $j++) {
+                $secretChar = $data[$i + $j] ?? 0;
+                $base = $base32charsFlipped[$secretChar] ?? 0;
+                $x .= str_pad(base_convert($base, 10, 2), 5, '0', STR_PAD_LEFT);
+            }
+            $eightBits = str_split($x, 8);
+            for ($z = 0; $z < count($eightBits); $z++) {
+                $binaryString .= ( ($y = chr(base_convert($eightBits[$z], 2, 10))) || ord($y) == 48 ) ? $y : "";
+            }
+        }
+
+        return $binaryString;
+    }
+}

--- a/src/OtpAuth/Paramters/Algorithm.php
+++ b/src/OtpAuth/Paramters/Algorithm.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Vectorface\OtpAuth\Paramters;
+
+enum Algorithm: string
+{
+    case SHA1 = 'SHA1';
+    case SHA256 = 'SHA256';
+    case SHA512 = 'SHA512';
+}

--- a/src/OtpAuth/Paramters/Type.php
+++ b/src/OtpAuth/Paramters/Type.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Vectorface\OtpAuth\Paramters;
+
+enum Type: string
+{
+    case TOTP = 'totp';
+    case HOTP = 'hotp';
+}

--- a/src/OtpAuth/UriBuilder.php
+++ b/src/OtpAuth/UriBuilder.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Vectorface\OtpAuth;
+
+use Vectorface\OtpAuth\Paramters\Algorithm;
+use Vectorface\OtpAuth\Paramters\Type;
+
+/**
+ * A TOTP/HOTP URI builder
+ *
+ * URIs should be in the format:
+ * otpauth://TYPE/LABEL?PARAMETERS
+ *
+ * Where:
+ *  - TYPE is one of "totp" (default) or "hotp"
+ *  - LABEL is the account or issue: account (encoded according to rfc3986)
+ *  - PARAMETERS are a set of encoded parameters that may/must include:
+ *      - secret: A base32-encoded secret (rfc3548)
+ *      - issuer: The provider or service with which the account is associated
+ *      - algorithm: One of sha1 (default), sha256, or sha512
+ *      - digits: Either 6 or 8
+ */
+class UriBuilder
+{
+    const SCHEME = "otpauth";
+    const DIGITS = [6, 8];
+
+    private string $secret;
+    private string $account = '';
+    private ?string $issuer = null;
+    private Type $type = Type::TOTP;
+    private ?Algorithm $algorithm = null;
+    private ?int $digits = null;
+    private ?int $counter = null;
+    private ?int $period = null;
+
+    /**
+     * @param string $secret
+     * @param bool $encode If true, also base32 encode the secret
+     * @return $this
+     */
+    public function secret(string $secret, bool $encode = false): self
+    {
+        $this->secret = $encode ? Base32::encode($secret) : $secret;
+        return $this;
+    }
+
+    public function account(string $account): self
+    {
+        $this->account = $account;
+        return $this;
+    }
+
+    public function issuer(string $issuer): self
+    {
+        $this->issuer = $issuer;
+        return $this;
+    }
+
+    public function type(Type $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function algorithm(Algorithm $algorithm): self
+    {
+        $this->algorithm = $algorithm;
+        return $this;
+    }
+
+    public function digits(int $digits): self
+    {
+        if (!in_array($digits, self::DIGITS)) {
+            throw new \InvalidArgumentException("Number of digits must be 6 or 8");
+        }
+        $this->digits = $digits;
+        return $this;
+    }
+
+    public function counter(int $counter): self
+    {
+        if ($counter < 0) {
+            throw new \InvalidArgumentException("Counter must be an integer greater than or equal to zero");
+        }
+        $this->counter = $counter;
+        return $this;
+    }
+
+    public function period(int $period): self
+    {
+        if ($period < 1) {
+            throw new \InvalidArgumentException("Period must be an integer greater than zero");
+        }
+        $this->period = $period;
+        return $this;
+    }
+
+    public function getUri(): string
+    {
+        if (!isset($this->secret)) {
+            throw new \DomainException("Secret is required for OTP URIs");
+        }
+
+        if ($this->type === Type::HOTP && !isset($this->counter)) {
+            throw new \DomainException("Counter is a required HOTP parameter");
+        }
+
+        if ($this->type === Type::TOTP && isset($this->counter)) {
+            throw new \DomainException("Counter parameter does not apply to TOTP");
+        }
+
+        if ($this->type === Type::HOTP && isset($this->period)) {
+            throw new \DomainException("Period parameter does not apply to HOTP");
+        }
+
+        $params = array_filter([
+            'secret'    => $this->secret,
+            'issuer'    => empty($this->issuer) ? $this->issuer : rawurlencode($this->issuer),
+            'algorithm' => $this->algorithm?->value,
+            'digits'    => $this->digits,
+            'counter'   => $this->counter,
+            'period'    => $this->period,
+        ]);
+
+        return sprintf(
+            "%s://%s/%s?%s",
+            self::SCHEME,
+            $this->type->value,
+            (empty($this->issuer) ? "" : (rawurlencode($this->issuer) . ":%20")) . rawurlencode($this->account),
+            implode('&', array_map(fn($k, $v) => "$k=$v", array_keys($params), array_values($params)))
+        );
+    }
+
+    public function __toString(): string
+    {
+        return $this->getUri();
+    }
+}

--- a/src/OtpAuth/UriBuilder.php
+++ b/src/OtpAuth/UriBuilder.php
@@ -2,6 +2,8 @@
 
 namespace Vectorface\OtpAuth;
 
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Writer\PngWriter;
 use Vectorface\OtpAuth\Paramters\Algorithm;
 use Vectorface\OtpAuth\Paramters\Type;
 
@@ -135,5 +137,16 @@ class UriBuilder
     public function __toString(): string
     {
         return $this->getUri();
+    }
+
+    public function getQRCodeDataUri(): string
+    {
+        return Builder::create()
+            ->data($this->getUri())
+            ->writer(new PngWriter)
+            ->size(260)
+            ->margin(10)
+            ->build()
+            ->getDataUri();
     }
 }

--- a/tests/GoogleAuthenticatorTest.php
+++ b/tests/GoogleAuthenticatorTest.php
@@ -5,6 +5,7 @@ namespace Tests\Vectorface;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Vectorface\GoogleAuthenticator;
+use Vectorface\OtpAuth\Paramters\Algorithm;
 
 class GoogleAuthenticatorTest extends TestCase
 {
@@ -176,5 +177,45 @@ class GoogleAuthenticatorTest extends TestCase
 
         $code = $this->googleAuthenticator->getCode($secret);
         $this->assertEquals('', $code);
+    }
+
+    /**
+     * Ensure URL builder emits correctly with minimal params
+     * @return void
+     */
+    public function testUriBuilderDefaults()
+    {
+        $builder = $this->googleAuthenticator->getUriBuilder()
+            ->account("foo")
+            ->secret("bar");
+
+        $this->assertEquals("otpauth://totp/foo?secret=bar", "$builder");
+    }
+
+    /**
+     * Ensure URL builder emits all params correctly
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testUriBuilderParams()
+    {
+        $secret = $this->googleAuthenticator->createSecret();
+        $digits = 8;
+        $period = 60;
+        $algorithm = Algorithm::SHA256;
+        $builder = $this->googleAuthenticator
+            ->setCodeLength(8)
+            ->getUriBuilder()
+                ->account("foo")
+                ->secret($secret)
+                ->issuer("bar+baz&quux")
+                ->algorithm($algorithm)
+                ->period($period);
+
+        $this->assertEquals(
+            "otpauth://totp/bar%2Bbaz%26quux:%20foo?secret={$secret}&issuer=bar%2Bbaz%26quux&algorithm={$algorithm->value}&digits={$digits}&period={$period}",
+            "$builder"
+        );
     }
 }

--- a/tests/OtpAuth/UriBuilderTest.php
+++ b/tests/OtpAuth/UriBuilderTest.php
@@ -19,7 +19,11 @@ class UriBuilderTest extends TestCase
             ->account("MyAcct")
             ->secret("FOO");
 
+        /* The builder can generate otpauth URLs */
         $this->assertEquals("otpauth://totp/MyAcct?secret=FOO", "$uriBuilder");
+
+        /* ... or QR codes as data URIs */
+        $this->assertStringStartsWith("data:image/png;base64,", $uriBuilder->getQRCodeDataUri());
 
         /* It is also possible to construct complex OTP URIs, including HOTP */
         $uriBuilder = (new UriBuilder())

--- a/tests/OtpAuth/UriBuilderTest.php
+++ b/tests/OtpAuth/UriBuilderTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Vectorface\OtpAuth;
+
+use PHPUnit\Framework\TestCase;
+use Vectorface\OtpAuth\Paramters\Type;
+use Vectorface\OtpAuth\UriBuilder;
+use Vectorface\OtpAuth\Paramters\Algorithm;
+
+class UriBuilderTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function synopsis()
+    {
+        /* URI builder basic usage: Provide an account name and secret */
+        $uriBuilder = (new UriBuilder())
+            ->account("MyAcct")
+            ->secret("FOO");
+
+        $this->assertEquals("otpauth://totp/MyAcct?secret=FOO", "$uriBuilder");
+
+        /* It is also possible to construct complex OTP URIs, including HOTP */
+        $uriBuilder = (new UriBuilder())
+            ->type(Type::HOTP)
+            ->account("My Account")
+            ->issuer("My Company")
+            ->secret("Raw Secret", true)
+            ->algorithm(Algorithm::SHA256)
+            ->digits(8)
+            ->counter(123);
+
+        $this->assertEquals('otpauth://hotp/My%20Company:%20My%20Account?secret=SBXATFDSFU&issuer=My%20Company&algorithm=SHA256&digits=8&counter=123', "$uriBuilder");
+    }
+
+    public function testInvalidType()
+    {
+        $this->expectException(\TypeError::class);
+        (new UriBuilder())
+            ->type("foo");
+    }
+
+    public function testInvalidAlgorithm()
+    {
+        $this->expectException(\TypeError::class);
+        (new UriBuilder())
+            ->algorithm("foo");
+    }
+
+    public function testMissingSecret()
+    {
+        $this->expectException(\DomainException::class);
+        (new UriBuilder())
+            ->getUri();
+    }
+
+    public function testMissingCounter()
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Counter is a required HOTP parameter");
+        (new UriBuilder())
+            ->secret("FOO")
+            ->type(Type::HOTP)
+            ->getUri();
+    }
+
+    public function testInvalidCounterUsage()
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Counter parameter does not apply to TOTP");
+        (new UriBuilder())
+            ->secret("FOO")
+            ->type(Type::TOTP)
+            ->counter(123)
+            ->getUri();
+    }
+
+    public function testInvalidPeriodUsage()
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Period parameter does not apply to HOTP");
+        (new UriBuilder())
+            ->secret("FOO")
+            ->type(Type::HOTP)
+            ->counter(0)
+            ->period(30)
+            ->getUri();
+    }
+
+    /**
+     * @dataProvider invalidArgumentsProvider
+     */
+    public function testInvalidArguments(string $message, int $digits, int $counter, int $period)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+        (new UriBuilder())
+            ->digits($digits)
+            ->period($period)
+            ->counter($counter);
+    }
+
+    public function invalidArgumentsProvider()
+    {
+        return [
+            "Digits must be positive" => ["Number of digits must be 6 or 8", 5, 0, 1],
+            "Counter must be positive" => ["Counter must be an integer greater than or equal to zero", 6, -1, 1],
+            "Period must be positive" => ["Period must be an integer greater than zero", 6, 0, 0],
+        ];
+    }
+}


### PR DESCRIPTION
PR #5 raised the issue of the `issuer` parameter being unavailable. This PR adds support for more (all) of the otpauth URI parameters (including issuer) by exposing a fluent URI builder interface. It also maintains backwards compatibility with the previous interface.

It should also be more compatible with the available specs I could find ([1](https://github.com/google/google-authenticator/wiki/Key-Uri-Format), [2](https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html), & [3](https://datatracker.ietf.org/doc/draft-linuxgemini-otpauth-uri/)), in that free-form strings are now correctly URI-encoded.

Using one of the examples, `otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example` would be generated with:

```php
(new GoogleAuthenticator())
    ->getUriBuilder()
    ->issuer("Example")
    ->account("alice@google.com")
    ->secret("JBSWY3DPEHPK3PXP")
    ->getUri();
```