### PR TITLE
fix missing issuer for QR codes generated by getQRCodeUrl method (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Google Authenticator (TOTP)
 
 ![Build Status](https://github.com/Vectorface/GoogleAuthenticator/workflows/Test/badge.svg)
 
+**English** | [中文](./README.zh-CN.md)
+
 This is a fork of https://github.com/PHPGangsta/GoogleAuthenticator with the following changes:
 
 - Uses https://github.com/endroid/qr-code to generate QR code data URIs

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ga = new GoogleAuthenticator();
 $secret = $ga->createSecret();
 echo "Secret is: {$secret}\n\n";
 
-$qrCodeUrl = $ga->getQRCodeUrl('Blog', $secret);
+$qrCodeUrl = $ga->getQRCodeUrl('Admin', $secret, 'Blog');
 echo "PNG Data URI for the QR-Code: {$qrCodeUrl}\n\n";
 
 $oneCode = $ga->getCode($secret);

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,81 @@
+Google Authenticator (TOTP)
+===========================
+
+![构建状态](https://github.com/Vectorface/GoogleAuthenticator/workflows/Test/badge.svg)
+
+**中文** | [English](./README.md)
+
+这是 https://github.com/PHPGangsta/GoogleAuthenticator 的一个分支，包含以下更改：
+
+- 使用 https://github.com/endroid/qr-code 生成二维码数据 URIs
+- 不再生成 Google 的 Chart API 来制作二维码链接
+- 使用命名空间
+- 将测试覆盖率增加到 100%
+- 将最低 PHP 版本提升到 8.1
+
+原始许可证：
+-----------------
+
+* 版权所有 (c) 2012-2016, [http://www.phpgangsta.de](http://www.phpgangsta.de)
+* 作者：Michael Kliewe, [@PHPGangsta](http://twitter.com/PHPGangsta) 和 [贡献者](https://github.com/PHPGangsta/GoogleAuthenticator/graphs/contributors)
+* 根据 BSD 许可证授权。
+
+描述：
+------------
+
+这个 PHP 类可以用来与 Google Authenticator 移动应用进行双重因素认证交互。该类可以生成密钥、生成代码、验证代码并提供用于扫描密钥的二维码。它实现了根据 [RFC6238](https://tools.ietf.org/html/rfc6238) 的 TOTP。
+
+为了您能安全安装，您必须确保使用的代码不能被重复使用（重放攻击）。您还需要限制验证次数，以对抗暴力攻击。例如，您可以将一个 IP 地址（或 IPv6 块）的验证次数限制为 10 分钟内 10 次尝试。这取决于您的环境。
+
+用法：
+------
+
+请参见以下示例：
+
+```php
+<?php
+require_once 'vendor/autoload.php';
+
+use Vectorface\GoogleAuthenticator;
+
+$ga = new GoogleAuthenticator();
+$secret = $ga->createSecret();
+echo "密钥是: {$secret}\n\n";
+
+$qrCodeUrl = $ga->getQRCodeUrl('Admin', $secret, 'Blog');
+echo "二维码的 PNG 数据 URI: {$qrCodeUrl}\n\n";
+
+$oneCode = $ga->getCode($secret);
+echo "检查代码 '$oneCode' 和密钥 '$secret':\n";
+
+// 2 = 2*30秒的时钟容差
+$checkResult = $ga->verifyCode($secret, $oneCode, 2);
+if ($checkResult) {
+    echo 'OK';
+} else {
+    echo 'FAILED';
+}
+```
+运行脚本会提供类似以下的输出：
+```
+密钥是: OQB6ZZGYHCPSX4AK
+
+二维码的 PNG 数据 URI: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAARgAAAEYCAIAAAAI[已截断]
+
+检查代码 '848634' 和密钥 'OQB6ZZGYHCPSX4AK':
+OK
+```
+
+安装：
+-------------
+
+- 使用 [Composer](https://getcomposer.org/doc/01-basic-usage.md) 安装包
+
+```composer require vectorface/googleauthenticator```
+
+运行测试：
+----------
+
+- 所有测试都在 `tests` 文件夹内。
+- 执行 `composer install` 来准备您的环境。
+- 从项目根目录运行 `composer test`。

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -92,15 +92,17 @@ class GoogleAuthenticator
     /**
      * Get QR-Code URL for image, from our native QRCode API
      *
-     * @param string $name
-     * @param string $secret
-     * @return string
+     * @param string $account Account Name
+     * @param string $secret A base32-encoded secret (rfc3548)
+     * @param string|null $issuer The provider or issuer with which the account is associated (optional)
+     * @return string Generate a QRCode for a given string
      * @throws Exception on encoding error
      */
-    public function getQRCodeUrl(string $name, string $secret) : string
+    public function getQRCodeUrl(string $account, string $secret, ?string $issuer = null) : string
     {
         $uri = $this->getUriBuilder()
-            ->account($name)
+            ->issuer($issuer)
+            ->account($account)
             ->secret($secret)
             ->getUri();
         return $this->getQRCodeDataUri($uri);

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -19,7 +19,7 @@ use Vectorface\OtpAuth\UriBuilder;
  */
 class GoogleAuthenticator
 {
-    protected $_codeLength = 6;
+    protected int $_codeLength = 6;
 
     /**
      * Create new secret.
@@ -157,7 +157,7 @@ class GoogleAuthenticator
         for ($i = -$discrepancy; $i <= $discrepancy; $i++) {
             try {
                 $calculatedCode = $this->getCode($secret, $currentTimeSlice + $i);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 return false;
             }
 

--- a/src/OtpAuth/UriBuilder.php
+++ b/src/OtpAuth/UriBuilder.php
@@ -53,7 +53,7 @@ class UriBuilder
         return $this;
     }
 
-    public function issuer(string $issuer): self
+    public function issuer(?string $issuer = null): self
     {
         $this->issuer = $issuer;
         return $this;

--- a/src/OtpAuth/UriBuilder.php
+++ b/src/OtpAuth/UriBuilder.php
@@ -15,7 +15,7 @@ use Vectorface\OtpAuth\Paramters\Type;
  *
  * Where:
  *  - TYPE is one of "totp" (default) or "hotp"
- *  - LABEL is the account or issue: account (encoded according to rfc3986)
+ *  - LABEL is the account or issuer: account (encoded according to rfc3986)
  *  - PARAMETERS are a set of encoded parameters that may/must include:
  *      - secret: A base32-encoded secret (rfc3548)
  *      - issuer: The provider or service with which the account is associated


### PR DESCRIPTION
1. fix missing issuer for QR codes generated by getQRCodeUrl method (optional)
2. Fix missing type declaration for $_codeLength attribute.
3. fix UriBuilder class introduction
4. remove unused local variables
5. Add Simplified Chinese README